### PR TITLE
Replaced protocol buffer parsing error with a simple one

### DIFF
--- a/src/main/java/io/dropwizard/jersey/protobuf/InvalidProtocolBufferExceptionMapper.java
+++ b/src/main/java/io/dropwizard/jersey/protobuf/InvalidProtocolBufferExceptionMapper.java
@@ -15,7 +15,7 @@ public class InvalidProtocolBufferExceptionMapper implements ExceptionMapper<Inv
     @Override
     public Response toResponse(InvalidProtocolBufferException exception) {
         final ErrorMessage message = ErrorMessage.newBuilder()
-                             .setMessage(exception.getMessage())
+                             .setMessage("Unable to process protocol buffer")
                              .setCode(Response.Status.BAD_REQUEST.getStatusCode())
                              .build();
 


### PR DESCRIPTION
Don't show the exception message in the protocol buffer response.  This follows dropwizard/dropwizard#694 and dropwizard/dropwizard#691
