### PR TITLE
Added support for protobuf text format serialization

### DIFF
--- a/src/main/java/io/dropwizard/jersey/protobuf/ProtocolBufferMediaType.java
+++ b/src/main/java/io/dropwizard/jersey/protobuf/ProtocolBufferMediaType.java
@@ -6,6 +6,9 @@ public class ProtocolBufferMediaType extends MediaType {
 
     /** "application/x-protobuf" */
     public final static String APPLICATION_PROTOBUF = "application/x-protobuf";
+    /** "application/x-protobuf,application/x-protobuf-text-format" */
+    public final static String APPLICATION_PROTOBUF_AND_TEXT_FORMAT = "application/x-protobuf,application/x-protobuf-text-format";
+
     /** "application/x-protobuf" */
     public final static MediaType APPLICATION_PROTOBUF_TYPE = new MediaType("application","x-protobuf");
 }


### PR DESCRIPTION
This is related to issue #12 -- Protobuf natively supports a text-serialization output format for debuggability (if you ever look at a Message in the debugger, you can see it there).  It's annoying to look at protocol buffers in Postman or other clients, so by including the header:

    Accept: application/x-protobuf-text-format

this change will light up the response in the text format instead.  It does not look to accept input messages in text format, as the primary motivation is for debugging.