### PR TITLE
cache to newBuilder method in ProtocolBufferMessageBodyProvider.

### DIFF
--- a/src/main/java/io/dropwizard/jersey/protobuf/ProtocolBufferMessageBodyProvider.java
+++ b/src/main/java/io/dropwizard/jersey/protobuf/ProtocolBufferMessageBodyProvider.java
@@ -50,6 +50,7 @@ public class ProtocolBufferMessageBodyProvider
             Method newBuilder = newBuilderMethodCache.get(type);
             if (newBuilder == null) {
                 newBuilder = type.getMethod("newBuilder");
+                newBuilderMethodCache.put(type, newBuilder);
             }
             final Message.Builder builder = (Message.Builder) newBuilder
                     .invoke(type);

--- a/src/main/java/io/dropwizard/jersey/protobuf/ProtocolBufferMessageBodyProvider.java
+++ b/src/main/java/io/dropwizard/jersey/protobuf/ProtocolBufferMessageBodyProvider.java
@@ -7,6 +7,9 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
@@ -28,6 +31,8 @@ import com.google.protobuf.TextFormat;
         ProtocolBufferMediaType.APPLICATION_PROTOBUF_TEXT })
 public class ProtocolBufferMessageBodyProvider
         implements MessageBodyReader<Message>, MessageBodyWriter<Message> {
+    
+    private final Map<Class<Message>, Method> newBuilderMethodCache = new ConcurrentHashMap<>();
 
     @Override
     public boolean isReadable(final Class<?> type, final Type genericType,
@@ -42,7 +47,10 @@ public class ProtocolBufferMessageBodyProvider
             final InputStream entityStream) throws IOException {
 
         try {
-            final Method newBuilder = type.getMethod("newBuilder");
+            Method newBuilder = newBuilderMethodCache.get(type);
+            if (newBuilder == null) {
+                newBuilder = type.getMethod("newBuilder");
+            }
             final Message.Builder builder = (Message.Builder) newBuilder
                     .invoke(type);
             return builder.mergeFrom(entityStream).build();

--- a/src/test/proto/dropwizard.proto
+++ b/src/test/proto/dropwizard.proto
@@ -9,3 +9,7 @@ option optimize_for = SPEED;
 message Example {
   int64 id = 1;
 };
+
+message Example2 {
+  string name = 1;
+};


### PR DESCRIPTION
A service typically uses a few message types on the other hand a service
could be serving thousands of requests/second so to minimize reflection calls
and the amount of garbadge generated as a result of it, it is possible to cache
the newBuilder method and re-use it.