### PR TITLE
Proposal to fix #23

### DIFF
--- a/src/main/java/io/dropwizard/jersey/protobuf/ProtocolBufferMessageBodyProvider.java
+++ b/src/main/java/io/dropwizard/jersey/protobuf/ProtocolBufferMessageBodyProvider.java
@@ -73,27 +73,28 @@ public class ProtocolBufferMessageBodyProvider
       final InputStream entityStream)
       throws IOException {
 
-    try {
-      final Method newBuilder =
-          methodCache.computeIfAbsent(
-              type,
-              t -> {
-                try {
-                  return t.getMethod("newBuilder");
-                } catch (Exception e) {
-                  return null;
-                }
-              });
+    final Method newBuilder =
+        methodCache.computeIfAbsent(
+            type,
+            t -> {
+              try {
+                return t.getMethod("newBuilder");
+              } catch (Exception e) {
+                return null;
+              }
+            });
 
-      final Message.Builder builder = (Message.Builder) newBuilder.invoke(type);
-      if (mediaType.getSubtype().contains("text-format")) {
-        TextFormat.merge(new InputStreamReader(entityStream, StandardCharsets.UTF_8), builder);
-        return builder.build();
-      } else {
-        return builder.mergeFrom(entityStream).build();
-      }
+    final Message.Builder builder;
+    try {
+      builder = (Message.Builder) newBuilder.invoke(type);
     } catch (Exception e) {
       throw new WebApplicationException(e);
+    }
+    if (mediaType.getSubtype().contains("text-format")) {
+      TextFormat.merge(new InputStreamReader(entityStream, StandardCharsets.UTF_8), builder);
+      return builder.build();
+    } else {
+      return builder.mergeFrom(entityStream).build();
     }
   }
 

--- a/src/test/java/io/dropwizard/jersey/protobuf/InvalidProtocolBufferExceptionMapperTest.java
+++ b/src/test/java/io/dropwizard/jersey/protobuf/InvalidProtocolBufferExceptionMapperTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2018 Smoke Turner, LLC (contact@smoketurner.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dropwizard.jersey.protobuf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.junit.Test;
+
+public class InvalidProtocolBufferExceptionMapperTest {
+
+  @Test
+  public void testExceptionMapperReturnsBadRequestResponseWhenInvalidProtocolBufferException() {
+    final InvalidProtocolBufferExceptionMapper mapper = new InvalidProtocolBufferExceptionMapper();
+    final Response actual =
+        mapper.toResponse(new InvalidProtocolBufferException("Something went wrong"));
+
+    assertThat(actual.getStatus()).isEqualTo(Status.BAD_REQUEST.getStatusCode());
+  }
+}

--- a/src/test/java/io/dropwizard/jersey/protobuf/ProtocolBufferMessageBodyProviderTest.java
+++ b/src/test/java/io/dropwizard/jersey/protobuf/ProtocolBufferMessageBodyProviderTest.java
@@ -18,6 +18,7 @@ package io.dropwizard.jersey.protobuf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import io.dropwizard.jersey.protobuf.protos.DropwizardProtosTest.Example;
 import io.dropwizard.jersey.protobuf.protos.DropwizardProtosTest.Example2;
@@ -26,7 +27,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.nio.charset.StandardCharsets;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MultivaluedHashMap;
 import org.glassfish.jersey.internal.util.collection.StringKeyIgnoreCaseMultivaluedMap;
 import org.junit.Test;
@@ -111,7 +111,7 @@ public class ProtocolBufferMessageBodyProviderTest {
   }
 
   @Test
-  public void throwsAWebApplicationExceptionForMalformedRequestEntities() throws Exception {
+  public void throwsInvalidProtocolBufferExceptionForMalformedRequestEntities() throws Exception {
     final ByteArrayInputStream entity =
         new ByteArrayInputStream("{\"id\":-1d".getBytes(StandardCharsets.UTF_8));
 
@@ -124,9 +124,8 @@ public class ProtocolBufferMessageBodyProviderTest {
           ProtocolBufferMediaType.APPLICATION_PROTOBUF_TYPE,
           new MultivaluedHashMap<String, String>(),
           entity);
-      failBecauseExceptionWasNotThrown(WebApplicationException.class);
-    } catch (WebApplicationException e) {
-      assertThat(e.getMessage()).startsWith("HTTP 500 Internal Server Error");
+      failBecauseExceptionWasNotThrown(InvalidProtocolBufferException.class);
+    } catch (InvalidProtocolBufferException e) {
     }
   }
 


### PR DESCRIPTION
Don't wrap protobuf decoding in the `try..catch`, instead let the `InvalidProtocolBufferException` bubble up. This way the `InvalidProtocolBufferExceptionMapper` should be able to catch it.