### PR TITLE
Using Zulu builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v2.2.0
       with:
-        distribution: "adopt"
+        distribution: "zulu"
         java-version: ${{ matrix.java_version }}
     - name: Build with Maven
       run: ./mvnw -B -V -ntp -ff -s .github/settings.xml -Dmaven.javadoc.skip=true install


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated builds for all versions of OpenJDK. 🥇 